### PR TITLE
Add limit to AplOptions

### DIFF
--- a/src/axiom_py/client.py
+++ b/src/axiom_py/client.py
@@ -108,6 +108,8 @@ class AplOptions:
     # IncludeCursor will return the Cursor as part of the query result, if set
     # to true.
     includeCursor: bool = field(default=False)
+    # The query limit.
+    limit: Optional[int] = field(default=None)
 
 
 class AxiomError(Exception):
@@ -350,11 +352,13 @@ class Client:  # pylint: disable=R0903
         self, opts: Optional[AplOptions]
     ) -> Dict[str, object]:
         """Prepare the apl query options for the request."""
-        params = {"format": AplResultFormat.Legacy.value}
+        params: Dict[str, object] = {"format": AplResultFormat.Legacy.value}
 
         if opts is not None:
             if opts.format:
                 params["format"] = opts.format.value
+            if opts.limit is not None:
+                params["request"] = {"limit": opts.limit}
 
         return params
 


### PR DESCRIPTION
This adds support for setting the limit in the AplOptions object so that the query limit can be specified as part of the request. Necessary to work around default limits imposed by the backend.