### PR TITLE
fix(axiom-py): Add `COMPUTED="computed"` `AggregationOption` to Enum

### DIFF
--- a/src/axiom_py/query/aggregation.py
+++ b/src/axiom_py/query/aggregation.py
@@ -10,6 +10,7 @@ class AggregationOperation(Enum):
     COUNTDISTINCTIF = "distinctif"
     MAKE_SET = "makeset"
     MAKE_SET_IF = "makesetif"
+    COMPUTED = "computed"
 
     # Only works for numbers.
     SUM = "sum"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,9 +125,9 @@ class TestClient(unittest.TestCase):
         )
         self.logger.debug(res)
 
-        assert (
-            res.ingested == 2
-        ), f"expected ingested count to equal 2, found {res.ingested}"
+        assert res.ingested == 2, (
+            f"expected ingested count to equal 2, found {res.ingested}"
+        )
         self.logger.info("ingested 2 events successfully.")
 
     def test_step002_ingest_events(self):
@@ -144,9 +144,9 @@ class TestClient(unittest.TestCase):
         )
         self.logger.debug(res)
 
-        assert (
-            res.ingested == 2
-        ), f"expected ingested count to equal 2, found {res.ingested}"
+        assert res.ingested == 2, (
+            f"expected ingested count to equal 2, found {res.ingested}"
+        )
 
     def test_step004_query(self):
         """Test querying a dataset"""


### PR DESCRIPTION
 ### Summary
 Axiom seems to have made a API change where the AggregationOption
 result coming down is now a "computed" value. When the axiom-py client
 retrieves the API response, it tries to parse it into a `QueryResult`
 and the enum validation against valid AggregationOptions fails.

 This PR adds the `COMPUTED = "computed"` value to the
 `AggregationOption` enum to resolve the parsing error

 NOTE: still talking with Axiom to determine _what_ this underlying
 change means, but the client is not failing and results seem to come
 back as expected

 ### Test Plan
 - Manually patched the enum locally, tested against Squares request with prod-ro

---

Resolves: RMN-